### PR TITLE
Local CI via tox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - GEXF format
 - Float weight support
+- `tox.ini`
 ### Changed
 - Menu optimized
 - `pyrgg.py` renamed to `graph_gen.py`

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,4 +9,4 @@ setuptools>=40.8.0
 vulture>=1.0
 bandit>=1.5.1
 pydocstyle>=3.0.0
-
+flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,4 +9,4 @@ setuptools>=40.8.0
 vulture>=1.0
 bandit>=1.5.1
 pydocstyle>=3.0.0
-flake8
+flake8>=3.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py35,py36,py37,py38,flake8
 
 [testenv]
 deps = -r dev-requirements.txt
 commands = pytest --cov=pyrgg/ test/
+
+[testenv:flake8]
+deps = -r dev-requirements.txt
+commands = flake8 pyrgg/ test/
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py35,py36,py37,py38
+
+[testenv]
+deps = -r dev-requirements.txt
+commands = pytest --cov=pyrgg/ test/
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,3 @@ commands = pytest --cov=pyrgg/ test/
 [testenv:flake8]
 deps = -r dev-requirements.txt
 commands = flake8 pyrgg/ test/
-
-


### PR DESCRIPTION
#### Reference Issues/PRs
NA

#### What does this implement/fix? Explain your changes.

To check locally that tests and code linting are fine, one can use ``tox``.
This allows one to catch bugs related to incompatibilities with the earlier python versions, for example.

Install:
```
pip install tox
```

Run:
```
tox
```

I added py35, py36, py38, py38 and flake8 environments.

#### Any other comments?

