### PR TITLE
Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- `load_config` function
 - `save_config` function
 ### Changed
 - `README.md` modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- `check_for_config` function
 - `load_config` function
 - `save_config` function
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `save_config` function
 ### Changed
 - `README.md` modified
 - Logo changed

--- a/pyrgg/__main__.py
+++ b/pyrgg/__main__.py
@@ -96,6 +96,9 @@ def run():
     input_dict = get_input()
     file_name = input_dict["file_name"]
     number_of_files = input_dict["number_of_files"]
+    if input_dict["config"] is True:
+        save_config(input_dict)
+    line(40)
     for i in range(number_of_files):
         print("Generating {0} from {1}".format(i + 1, number_of_files))
         file_name_temp = file_name

--- a/pyrgg/__main__.py
+++ b/pyrgg/__main__.py
@@ -97,10 +97,10 @@ def run(input_dict=None):
     """
     if input_dict is None:
         input_dict = get_input()
+        if input_dict["config"] is True:
+            print("Config --> " + save_config(input_dict))
     file_name = input_dict["file_name"]
     number_of_files = input_dict["number_of_files"]
-    if input_dict["config"] is True:
-        print("Config --> " + save_config(input_dict))
     line(40)
     for i in range(number_of_files):
         print("Generating {0} from {1}".format(i + 1, number_of_files))

--- a/pyrgg/__main__.py
+++ b/pyrgg/__main__.py
@@ -100,7 +100,7 @@ def run(input_dict=None):
     file_name = input_dict["file_name"]
     number_of_files = input_dict["number_of_files"]
     if input_dict["config"] is True:
-        save_config(input_dict)
+        print("Config --> " + save_config(input_dict))
     line(40)
     for i in range(number_of_files):
         print("Generating {0} from {1}".format(i + 1, number_of_files))

--- a/pyrgg/__main__.py
+++ b/pyrgg/__main__.py
@@ -87,13 +87,16 @@ def gen_graph(input_dict, file_name):
         elapsed_time_format)
 
 
-def run():
+def run(input_dict=None):
     """
     Run proper converter.
 
+    :param input_dict: input data
+    :type input_dict: dict
     :return: None
     """
-    input_dict = get_input()
+    if input_dict is None:
+        input_dict = get_input()
     file_name = input_dict["file_name"]
     number_of_files = input_dict["number_of_files"]
     if input_dict["config"] is True:
@@ -116,6 +119,7 @@ def main():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', help='version', nargs="?", const=1)
+    parser.add_argument('--config', help='config')
     parser.add_argument('test', help='test', nargs="?", const=1)
     args = parser.parse_args()
     if args.version:
@@ -131,8 +135,11 @@ def main():
         tprint("v" + PYRGG_VERSION)
         description_print()
         EXIT_FLAG = False
+        input_dict = None
         while not EXIT_FLAG:
-            run()
+            if args.config:
+                input_dict = load_config(args.config)
+            run(input_dict)
             INPUTINDEX = str(
                 input("Press [R] to restart Pyrgg or any other key to exit."))
             if INPUTINDEX.upper() != "R":

--- a/pyrgg/__main__.py
+++ b/pyrgg/__main__.py
@@ -139,6 +139,8 @@ def main():
         while not EXIT_FLAG:
             if args.config:
                 input_dict = load_config(args.config)
+            else:
+                input_dict = check_for_config()
             run(input_dict)
             INPUTINDEX = str(
                 input("Press [R] to restart Pyrgg or any other key to exit."))

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -631,6 +631,6 @@ def load_config(path):
     """
     try:
         with open(path, "r") as json_file:
-            return json_loads(json_file.read())
+            return input_filter(json_loads(json_file.read()))
     except FileNotFoundError:
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -612,7 +612,7 @@ def save_config(input_dict):
     :type input_dict: dict
     :return: None
     """
-    fname = input_dict['file_name'] + ".config.json"
+    fname = pyrgg.params.CONFIG_FILE_FORMAT.format(input_dict['file_name'])
     try:
         with open(fname, "w") as json_file:
             json_dump(input_dict, json_file, indent=2)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -634,7 +634,7 @@ def load_config(path):
     try:
         with open(path, "r") as json_file:
             config = json_loads(json_file.read())
-            config['output_format'] = pyrgg.params.OUTPUT_FORMAT_inv[config['output_format']]
+            config['output_format'] = pyrgg.params.OUTPUT_FORMAT_INV[config['output_format']]
             return input_filter(config)
     except BaseException:
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -619,3 +619,18 @@ def save_config(input_dict):
         print("Config --> " + os.path.abspath(fname))
     except FileNotFoundError:
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
+
+
+def load_config(path):
+    """
+    Load config based on given path.
+
+    :param path: path to config file
+    :type path: str
+    :return: input dictionary
+    """
+    try:
+        with open(path, "r") as json_file:
+            return json_loads(json_file.read())
+    except FileNotFoundError:
+        print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -634,3 +634,39 @@ def load_config(path):
             return input_filter(json_loads(json_file.read()))
     except FileNotFoundError:
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
+
+
+def _print_select_config(configs):
+    """
+    Print configs in current directory and get input from user.
+
+    :param configs: configs path
+    :type configs: list
+    :return: desired config path
+    """
+    if configs == []:
+        return None
+    print("Config files detected in current directory are listed below:")
+    for i, config in enumerate(configs):
+        print("[{}] - {}".format(i, config))
+    key = input(
+        "Press the config index to load or any other keys to start with new one : ")
+    try:
+        return load_config(configs[int(key)])
+    except BaseException:
+        return None
+
+
+def check_for_config():
+    """
+    Check for config files in source directory.
+
+    :return: input dictionary if available, otherwise None
+    """
+    configs = []
+    for filename in os.listdir(pyrgg.params.SOURCE_DIR):
+        file = os.path.join(pyrgg.params.SOURCE_DIR, filename)
+        if os.path.isfile(file) and filename.endswith(
+                pyrgg.params.CONFIG_FILE_FORMAT.format("")):
+            configs.append(file)
+    return _print_select_config(configs)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -640,7 +640,7 @@ def load_config(path):
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
 
 
-def _print_select_config(configs, input_func=input):  # pragma: no cover
+def _print_select_config(configs, input_func=input):
     """
     Print configs in current directory and get input from user.
 

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -610,15 +610,15 @@ def save_config(input_dict):
 
     :param input_dict: input dictionary
     :type input_dict: dict
-    :return: None
+    :return: path to file
     """
-    fname = pyrgg.params.CONFIG_FILE_FORMAT.format(input_dict['file_name'])
     try:
+        fname = pyrgg.params.CONFIG_FILE_FORMAT.format(input_dict['file_name'])
         with open(fname, "w") as json_file:
             json_dump(input_dict, json_file, indent=2)
-        print("Config --> " + os.path.abspath(fname))
-    except FileNotFoundError:
-        print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
+        return os.path.abspath(fname)
+    except BaseException:
+        print(pyrgg.params.PYRGG_INPUT_ERROR_MESSAGE)
 
 
 def load_config(path):
@@ -632,11 +632,11 @@ def load_config(path):
     try:
         with open(path, "r") as json_file:
             return input_filter(json_loads(json_file.read()))
-    except FileNotFoundError:
+    except BaseException:
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
 
 
-def _print_select_config(configs, input_func=input):
+def _print_select_config(configs, input_func=input):  # pragma: no cover
     """
     Print configs in current directory and get input from user.
 
@@ -649,7 +649,7 @@ def _print_select_config(configs, input_func=input):
     print("Config files detected in current directory are listed below:")
     for i, config in enumerate(configs):
         print("[{}] - {}".format(i, config))
-    key = input(
+    key = input_func(
         "Press the config index to load or any other keys to start with new one : ")
     try:
         return load_config(configs[int(key)])

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -2,6 +2,7 @@
 """Pyrgg functions module."""
 import datetime
 from json import loads as json_loads
+from json import dump as json_dump
 import os
 from pickle import dump as pickle_dump
 from random import randint, uniform, choice
@@ -83,7 +84,7 @@ def convert_str_to_bool(string):
     return bool(int(string))
 
 
-MENU_ITEM_CONVERTORS = {
+ITEM_CONVERTORS = {
     "file_name": lambda x: x,
     "output_format": int,
     "weight": convert_str_to_bool,
@@ -97,6 +98,7 @@ MENU_ITEM_CONVERTORS = {
     "direct": convert_str_to_bool,
     "self_loop": convert_str_to_bool,
     "multigraph": convert_str_to_bool,
+    "config": convert_str_to_bool,
 }
 
 
@@ -305,6 +307,7 @@ def get_input(input_func=input):
         "direct": True,
         "self_loop": True,
         "multigraph": False,
+        "config": False,
     }
 
     result_dict = _update_using_first_menu(result_dict, input_func)
@@ -326,7 +329,7 @@ def _update_using_first_menu(result_dict, input_func):
     for item in MENU_ITEMS_KEYS1:
         while True:
             try:
-                result_dict[item] = MENU_ITEM_CONVERTORS[item](
+                result_dict[item] = ITEM_CONVERTORS[item](
                     input_func(pyrgg.params.MENU_ITEMS1[item])
                 )
             except Exception:
@@ -354,7 +357,7 @@ def _update_using_second_menu(result_dict, input_func):
             continue
         while True:
             try:
-                result_dict[item1] = MENU_ITEM_CONVERTORS[item1](
+                result_dict[item1] = ITEM_CONVERTORS[item1](
                     input_func(item2)
                 )
             except Exception:
@@ -597,5 +600,22 @@ def json_to_pickle(filename):
             json_data = json_loads(json_file.read())
             with open(filename + ".p", "wb") as pickle_file:
                 pickle_dump(json_data, pickle_file)
+    except FileNotFoundError:
+        print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
+
+
+def save_config(input_dict):
+    """
+    Save input_dict as the generation config.
+
+    :param input_dict: input dictionary
+    :type input_dict: dict
+    :return: dictionary indciating result
+    """
+    fname = input_dict['file_name'] + ".config.json"
+    try:
+        with open(fname, "w") as json_file:
+            json_dump(input_dict, json_file, indent=2)
+        print("Config --> " + os.path.abspath(fname))
     except FileNotFoundError:
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -613,6 +613,8 @@ def save_config(input_dict):
     :return: path to file
     """
     try:
+        input_dict['pyrgg_version'] = pyrgg.params.PYRGG_VERSION
+        input_dict['output_format'] = pyrgg.params.OUTPUT_FORMAT[input_dict['output_format']]
         fname = pyrgg.params.CONFIG_FILE_FORMAT.format(input_dict['file_name'])
         with open(fname, "w") as json_file:
             json_dump(input_dict, json_file, indent=2)
@@ -631,7 +633,9 @@ def load_config(path):
     """
     try:
         with open(path, "r") as json_file:
-            return input_filter(json_loads(json_file.read()))
+            config = json_loads(json_file.read())
+            config['output_format'] = pyrgg.params.OUTPUT_FORMAT_inv[config['output_format']]
+            return input_filter(config)
     except BaseException:
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
 

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -636,7 +636,7 @@ def load_config(path):
         print(pyrgg.params.PYRGG_FILE_ERROR_MESSAGE)
 
 
-def _print_select_config(configs):
+def _print_select_config(configs, input_func=input):
     """
     Print configs in current directory and get input from user.
 
@@ -657,7 +657,7 @@ def _print_select_config(configs):
         return None
 
 
-def check_for_config():
+def check_for_config(input_func=input):
     """
     Check for config files in source directory.
 
@@ -669,4 +669,4 @@ def check_for_config():
         if os.path.isfile(file) and filename.endswith(
                 pyrgg.params.CONFIG_FILE_FORMAT.format("")):
             configs.append(file)
-    return _print_select_config(configs)
+    return _print_select_config(configs, input_func)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -610,7 +610,7 @@ def save_config(input_dict):
 
     :param input_dict: input dictionary
     :type input_dict: dict
-    :return: dictionary indciating result
+    :return: None
     """
     fname = input_dict['file_name'] + ".config.json"
     try:

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -63,7 +63,8 @@ SUFFIX_MENU = {
     16: ".gv"
 }
 
-OUTPUT_FORMAT = {i: output_format[1:].upper() for i, output_format in SUFFIX_MENU.items()}
+OUTPUT_FORMAT = {i: output_format[1:].upper()
+                 for i, output_format in SUFFIX_MENU.items()}
 
 OUTPUT_FORMAT_inv = {v: k for k, v in OUTPUT_FORMAT.items()}
 

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -66,7 +66,7 @@ SUFFIX_MENU = {
 OUTPUT_FORMAT = {i: output_format[1:].upper()
                  for i, output_format in SUFFIX_MENU.items()}
 
-OUTPUT_FORMAT_inv = {v: k for k, v in OUTPUT_FORMAT.items()}
+OUTPUT_FORMAT_INV = {v: k for k, v in OUTPUT_FORMAT.items()}
 
 
 PYRGG_VERSION = "1.3"

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -70,6 +70,8 @@ PYRGG_TEST_MODE = False
 
 SOURCE_DIR = os.getcwd()
 
+CONFIG_FILE_FORMAT = "{}.pyrgg.config.json"
+
 PYRGG_LINKS = """
 Webpage : https://www.pyrgg.ir
 Repository : https://github.com/sepandhaghighi/pyrgg

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -39,7 +39,8 @@ MENU_ITEMS2 = {
     6: ["sign", "- Unsigned[0] or Signed[1]"],
     7: ["direct", "- Undirected[0] or Directed[1]"],
     8: ["self_loop", "- No Self Loop[0] or Self Loop[1]"],
-    9: ["multigraph", "- Simple[0] or Multigraph[1]"]
+    9: ["multigraph", "- Simple[0] or Multigraph[1]"],
+    10: ["config", "- Save config[1] or not[0]"],
 }
 
 

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -63,6 +63,10 @@ SUFFIX_MENU = {
     16: ".gv"
 }
 
+OUTPUT_FORMAT = {i: output_format[1:].upper() for i, output_format in SUFFIX_MENU.items()}
+
+OUTPUT_FORMAT_inv = {v: k for k, v in OUTPUT_FORMAT.items()}
+
 
 PYRGG_VERSION = "1.3"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 # content of pytest.ini
 [pytest]
 addopts = --doctest-modules
-doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -216,8 +216,14 @@ True
 >>> loaded_config = check_for_config(input_func_conf_test)
 >>> input_data["config"]
 True
+>>> input_data_ = input_data.copy()
 >>> config_path = save_config(input_data)
->>> input_data == load_config(config_path)
+>>> loaded_config = load_config(config_path)
+>>> loaded_config["vertices"] == input_data_["vertices"]
+True
+>>> loaded_config["number_of_files"] == input_data_["number_of_files"]
+True
+>>> loaded_config["output_format"] == input_data_["output_format"]
 True
 >>> save_config("test")
 [Error] Bad Input!

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -3,6 +3,7 @@
 >>> from pyrgg.functions import *
 >>> import pyrgg.params
 >>> import random
+>>> import os
 >>> pyrgg.params.PYRGG_TEST_MODE = True
 >>> description_print()
 Webpage : https://www.pyrgg.ir
@@ -153,7 +154,7 @@ Traceback (most recent call last):
         ...
 TypeError: edge_gen() missing 1 required positional argument: 'sign'
 >>> prev_item = ""
->>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":3}
+>>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":3,"config":False}
 >>> def input_func_test(input_data):
 ...    global prev_item
 ...    for item in pyrgg.params.MENU_ITEMS1:
@@ -172,6 +173,10 @@ TypeError: edge_gen() missing 1 required positional argument: 'sign'
 ...                return input_func_dict[item1]
 ...            else:
 ...                return input_func_dict["error"]
+>>> conf_input = "0"
+>>> def input_func_conf_test(input_data):
+...     global conf_input
+...     return conf_input
 >>> input_data = get_input(input_func_test)
 >>> input_data["vertices"]
 120
@@ -190,7 +195,7 @@ True
 >>> input_data["weight"]
 True
 >>> prev_item = ""
->>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"1.2","min_edge":"10000","max_edge":"2","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":-1}
+>>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"1.2","min_edge":"10000","max_edge":"2","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":-1,"config":True}
 >>> input_data = get_input(input_func_test)
 >>> input_data["vertices"]
 120
@@ -208,8 +213,18 @@ True
 True
 >>> input_data["weight"]
 True
+>>> loaded_config = check_for_config(input_func_conf_test)
+>>> input_data["config"]
+True
+>>> config_path = save_config(input_data)
+>>> input_data == load_config(config_path)
+True
+>>> save_config("test")
+[Error] Bad Input!
+>>> load_config("test123456789")
+[Error] Bad Input File!
 >>> prev_item = ""
->>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"0","multigraph":"0","file_name":"File 2","output_format":"200","weight":"0","number_of_files":-1,"error":"120"}
+>>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"0","multigraph":"0","file_name":"File 2","output_format":"200","weight":"0","number_of_files":-1,"error":"120","config":False}
 >>> input_data = get_input(input_func_test)
 >>> input_data["vertices"]
 120
@@ -227,17 +242,17 @@ True
 True
 >>> input_data["multigraph"]
 False
->>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"2","multigraph":"400","file_name":"File 2","output_format":"200","weight":"1","error":"120","number_of_files":2}
+>>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"2","multigraph":"400","file_name":"File 2","output_format":"200","weight":"1","error":"120","number_of_files":2,"config":False}
 >>> input_data = get_input(input_func_test)
 [Error] Bad Input!
 >>> input_data["min_weight"]
 110.45
 >>> input_data["max_weight"]
 120
->>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"1","file_name":"File 1","output_format":"2","weight":"test","error":"2","number_of_files":2}
+>>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"1","file_name":"File 1","output_format":"2","weight":"test","error":"2","number_of_files":2,"config":False}
 >>> input_data = get_input(input_func_test)
 [Error] Bad Input!
 >>> input_data["weight"]
 True
-
+>>> os.remove('File 1.pyrgg.config.json')
 """

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -232,7 +232,6 @@ True
 >>> loaded_config = check_for_config(input_func_conf_test0)
 Config files detected in current directory are listed below:
 [0] - ...
-Press the config index to load or any other keys to start with new one : 
 >>> loaded_config["vertices"] == input_data_["vertices"]
 True
 >>> loaded_config["number_of_files"] == input_data_["number_of_files"]
@@ -242,7 +241,6 @@ True
 >>> loaded_config = check_for_config(input_func_conf_test1)
 Config files detected in current directory are listed below:
 [0] - ...
-Press the config index to load or any other keys to start with new one : 
 >>> loaded_config == None
 True
 >>> prev_item = ""

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -173,10 +173,10 @@ TypeError: edge_gen() missing 1 required positional argument: 'sign'
 ...                return input_func_dict[item1]
 ...            else:
 ...                return input_func_dict["error"]
->>> conf_input = "0"
->>> def input_func_conf_test(input_data):
-...     global conf_input
-...     return conf_input
+>>> def input_func_conf_test0(input_data):
+...     return "0"
+>>> def input_func_conf_test1(input_data):
+...     return "1"
 >>> input_data = get_input(input_func_test)
 >>> input_data["vertices"]
 120
@@ -213,7 +213,7 @@ True
 True
 >>> input_data["weight"]
 True
->>> loaded_config = check_for_config(input_func_conf_test)
+>>> loaded_config = check_for_config(input_func_conf_test0)
 >>> input_data["config"]
 True
 >>> input_data_ = input_data.copy()
@@ -229,6 +229,22 @@ True
 [Error] Bad Input!
 >>> load_config("test123456789")
 [Error] Bad Input File!
+>>> loaded_config = check_for_config(input_func_conf_test0)
+Config files detected in current directory are listed below:
+[0] - ...
+Press the config index to load or any other keys to start with new one : 
+>>> loaded_config["vertices"] == input_data_["vertices"]
+True
+>>> loaded_config["number_of_files"] == input_data_["number_of_files"]
+True
+>>> loaded_config["output_format"] == input_data_["output_format"]
+True
+>>> loaded_config = check_for_config(input_func_conf_test1)
+Config files detected in current directory are listed below:
+[0] - ...
+Press the config index to load or any other keys to start with new one : 
+>>> loaded_config == None
+True
 >>> prev_item = ""
 >>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"0","multigraph":"0","file_name":"File 2","output_format":"200","weight":"0","number_of_files":-1,"error":"120","config":False}
 >>> input_data = get_input(input_func_test)


### PR DESCRIPTION
#### Reference Issues/PRs
#43 
#### What does this implement/fix? Explain your changes.
The process for saving and loading a config file is now such that you can use either `--config` argument while running `pyrgg` or choose your desired config (which should be located at the source where you are running `pyrgg`). You will be asked as the final question if you wanted to save the config by which you generate graph(s) each time after generation. Below changes are also applied:
- `check_for_config` function
- `load_config` function
- `save_config` function

#### Any other comments?
The only point I missed is the test for `_print_select_config` in the case where' configs' are not empty. I tried the below pytest code but it failed, I don't know why. Maybe @sepandhaghighi can help me with this. BTW I went with `# pragma: no cover` for now.
```python
>>> loaded_config = check_for_config(input_func_conf_test)
Config files detected in current directory are listed below:
[0] - (.*)
Press the config index to load or any other keys to start with new one : 
```