### PR TITLE
Engine param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Generation engine menu
+### Changed
+- `MENU_ITEMS1` parameter changed to `MENU_ITEMS`
+- `MENU_ITEMS2` parameter changed to `PYRGG_ENGINE_PARAMS`
 ## [1.4] - 2023-07-06
 ### Added
 - `check_for_config` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- generation engine menu
+- Generation engine menu
 ## [1.4] - 2023-07-06
 ### Added
 - `check_for_config` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `MENU_ITEMS1` parameter changed to `MENU_ITEMS`
 - `MENU_ITEMS2` parameter changed to `PYRGG_ENGINE_PARAMS`
 - `_update_using_first_menu` function changed to `_update_using_menu`
-- `_update_using_second_menu` function changed to `_update_with_pyrgg_engine`
+- `_update_using_second_menu` function changed to `_update_with_engine_params`
 ## [1.4] - 2023-07-06
 ### Added
 - `check_for_config` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- generation engine menu
 ## [1.4] - 2023-07-06
 ### Added
 - `check_for_config` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `MENU_ITEMS1` parameter changed to `MENU_ITEMS`
 - `MENU_ITEMS2` parameter changed to `PYRGG_ENGINE_PARAMS`
+- `_update_using_first_menu` function changed to `_update_using_menu`
+- `_update_using_second_menu` function changed to `_update_with_pyrgg_engine`
 ## [1.4] - 2023-07-06
 ### Added
 - `check_for_config` function

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -277,7 +277,8 @@ def input_filter(input_dict):
             range(1, len(pyrgg.params.SUFFIX_MENU) + 1)):
         filtered_dict["output_format"] = 1
 
-    if filtered_dict["engine"] not in list(range(1, len(pyrgg.params.ENGINE_MENU) + 1)):
+    if filtered_dict["engine"] not in list(
+            range(1, len(pyrgg.params.ENGINE_MENU) + 1)):
         filtered_dict["engine"] = 1
 
     if not filtered_dict["multigraph"]:
@@ -622,7 +623,8 @@ def save_config(input_dict):
         input_dict_temp['engine'] = pyrgg.params.ENGINE_MENU[input_dict_temp['engine']]
         input_dict_temp['pyrgg_version'] = pyrgg.params.PYRGG_VERSION
         input_dict_temp['output_format'] = pyrgg.params.OUTPUT_FORMAT[input_dict_temp['output_format']]
-        fname = pyrgg.params.CONFIG_FILE_FORMAT.format(input_dict_temp['file_name'])
+        fname = pyrgg.params.CONFIG_FILE_FORMAT.format(
+            input_dict_temp['file_name'])
         with open(fname, "w") as json_file:
             json_dump(input_dict_temp, json_file, indent=2)
         return os.path.abspath(fname)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -319,6 +319,8 @@ def get_input(input_func=input):
     result_dict = _update_using_menu(result_dict, input_func)
     if result_dict['engine'] == 1:
         result_dict = _update_with_pyrgg_engine(result_dict, input_func)
+    else:
+        print(pyrgg.params.PYRGG_INVALID_ENGINE_ERROR_MESSAGE)
     return input_filter(result_dict)
 
 

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -88,6 +88,7 @@ ITEM_CONVERTORS = {
     "file_name": lambda x: x,
     "output_format": int,
     "weight": convert_str_to_bool,
+    "engine": int,
     "vertices": int,
     "number_of_files": int,
     "max_weight": convert_str_to_number,
@@ -276,6 +277,9 @@ def input_filter(input_dict):
             range(1, len(pyrgg.params.SUFFIX_MENU) + 1)):
         filtered_dict["output_format"] = 1
 
+    if filtered_dict["engine"] not in list(range(1, len(pyrgg.params.ENGINE_MENU) + 1)):
+        filtered_dict["engine"] = 1
+
     if not filtered_dict["multigraph"]:
         for key in ["min_edge", "max_edge"]:
             filtered_dict[key] = min(filtered_dict[key], edge_upper_threshold)
@@ -304,6 +308,7 @@ def get_input(input_func=input):
         "sign": True,
         "output_format": 1,
         "weight": True,
+        "engine": 1,
         "direct": True,
         "self_loop": True,
         "multigraph": False,
@@ -614,7 +619,7 @@ def save_config(input_dict):
     """
     try:
         input_dict_temp = input_dict.copy()
-        input_dict_temp["engine"] = "pyrgg"
+        input_dict_temp['engine'] = pyrgg.params.ENGINE_MENU[input_dict_temp['engine']]
         input_dict_temp['pyrgg_version'] = pyrgg.params.PYRGG_VERSION
         input_dict_temp['output_format'] = pyrgg.params.OUTPUT_FORMAT[input_dict_temp['output_format']]
         fname = pyrgg.params.CONFIG_FILE_FORMAT.format(input_dict_temp['file_name'])
@@ -637,6 +642,7 @@ def load_config(path):
         with open(path, "r") as json_file:
             config = json_loads(json_file.read())
             config['output_format'] = pyrgg.params.OUTPUT_FORMAT_INV[config['output_format']]
+            config['engine'] = pyrgg.params.ENGINE_MENU_INV[config['engine']]
             return input_filter(config)
     except BaseException:
         print(pyrgg.params.PYRGG_CONFIG_LOAD_ERROR_MESSAGE)

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -317,10 +317,8 @@ def get_input(input_func=input):
     }
 
     result_dict = _update_using_menu(result_dict, input_func)
-    if result_dict['engine'] == 1:
-        result_dict = _update_with_pyrgg_engine(result_dict, input_func)
-    else:
-        print(pyrgg.params.PYRGG_INVALID_ENGINE_ERROR_MESSAGE)
+    result_dict = _update_with_engine_params(
+        result_dict, input_func, pyrgg.params.ENGINE_PARAM_MAP[result_dict['engine']])
     return input_filter(result_dict)
 
 
@@ -348,20 +346,21 @@ def _update_using_menu(result_dict, input_func):
     return result_dict
 
 
-def _update_with_pyrgg_engine(result_dict, input_func):
+def _update_with_engine_params(result_dict, input_func, engine_params):
     """
-    Update result_dict using user input based on pyrgg engine requirements.
+    Update result_dict using user input based on given engine requirements.
 
     :param result_dict: result data
     :type result_dict: dict
     :param input_func: input function
     :type input_func: function object
+    :param engine_params: engine parameters
+    :type engine_params: dict
     :return: result_dict as dict
     """
-    ENGINE_PARAMS = sorted(list(pyrgg.params.PYRGG_ENGINE_PARAMS.keys()))
+    ENGINE_PARAMS = sorted(list(engine_params.keys()))
     for index in ENGINE_PARAMS:
-        item1 = pyrgg.params.PYRGG_ENGINE_PARAMS[index][0]
-        item2 = pyrgg.params.PYRGG_ENGINE_PARAMS[index][1]
+        item1, item2 = engine_params[index]
         if not result_dict["weight"] and item1 in ["max_weight", "min_weight"]:
             continue
         while True:

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -316,14 +316,15 @@ def get_input(input_func=input):
         "config": False,
     }
 
-    result_dict = _update_using_first_menu(result_dict, input_func)
-    result_dict = _update_using_second_menu(result_dict, input_func)
+    result_dict = _update_using_menu(result_dict, input_func)
+    if result_dict['engine'] == 1:
+        result_dict = _update_with_pyrgg_engine(result_dict, input_func)
     return input_filter(result_dict)
 
 
-def _update_using_first_menu(result_dict, input_func):
+def _update_using_menu(result_dict, input_func):
     """
-    Update result_dict using user input from the first menu.
+    Update result_dict using user input from the menu.
 
     :param result_dict: result data
     :type result_dict: dict
@@ -345,9 +346,9 @@ def _update_using_first_menu(result_dict, input_func):
     return result_dict
 
 
-def _update_using_second_menu(result_dict, input_func):
+def _update_with_pyrgg_engine(result_dict, input_func):
     """
-    Update result_dict using user input from the second menu.
+    Update result_dict using user input based on pyrgg engine requirements.
 
     :param result_dict: result data
     :type result_dict: dict

--- a/pyrgg/functions.py
+++ b/pyrgg/functions.py
@@ -331,12 +331,12 @@ def _update_using_first_menu(result_dict, input_func):
     :type input_func: function object
     :return: result_dict as dict
     """
-    MENU_ITEMS_KEYS1 = sorted(list(pyrgg.params.MENU_ITEMS1.keys()))
-    for item in MENU_ITEMS_KEYS1:
+    MENU_ITEMS_KEYS = sorted(list(pyrgg.params.MENU_ITEMS.keys()))
+    for item in MENU_ITEMS_KEYS:
         while True:
             try:
                 result_dict[item] = ITEM_CONVERTORS[item](
-                    input_func(pyrgg.params.MENU_ITEMS1[item])
+                    input_func(pyrgg.params.MENU_ITEMS[item])
                 )
             except Exception:
                 print(pyrgg.params.PYRGG_INPUT_ERROR_MESSAGE)
@@ -355,10 +355,10 @@ def _update_using_second_menu(result_dict, input_func):
     :type input_func: function object
     :return: result_dict as dict
     """
-    MENU_ITEMS_KEYS2 = sorted(list(pyrgg.params.MENU_ITEMS2.keys()))
-    for index in MENU_ITEMS_KEYS2:
-        item1 = pyrgg.params.MENU_ITEMS2[index][0]
-        item2 = pyrgg.params.MENU_ITEMS2[index][1]
+    ENGINE_PARAMS = sorted(list(pyrgg.params.PYRGG_ENGINE_PARAMS.keys()))
+    for index in ENGINE_PARAMS:
+        item1 = pyrgg.params.PYRGG_ENGINE_PARAMS[index][0]
+        item2 = pyrgg.params.PYRGG_ENGINE_PARAMS[index][1]
         if not result_dict["weight"] and item1 in ["max_weight", "min_weight"]:
             continue
         while True:

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -113,6 +113,8 @@ PYRGG_INPUT_ERROR_MESSAGE = "[Error] Bad input!"
 
 PYRGG_FILE_ERROR_MESSAGE = "[Error] Bad input file!"
 
+PYRGG_INVALID_ENGINE_ERROR_MESSAGE = "[Error] Invalid engine!"
+
 PYRGG_YAML_ERROR_MESSAGE = "[Error] Failed to generate YAML file!"
 
 PYRGG_PICKLE_ERROR_MESSAGE = "[Error] Failed to generate Pickle file!"

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -74,6 +74,10 @@ ENGINE_MENU = {
 
 ENGINE_MENU_INV = {v: k for k, v in ENGINE_MENU.items()}
 
+ENGINE_PARAM_MAP = {
+    1: PYRGG_ENGINE_PARAMS,
+}
+
 OUTPUT_FORMAT = {i: output_format[1:].upper()
                  for i, output_format in SUFFIX_MENU.items()}
 

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -28,6 +28,12 @@ MENU_ITEMS1 = {
         """
     ),
     "weight": "- Unweighted[0] or Weighted[1]",
+    "engine": dedent(
+        """\
+        - Select generation engine :
+        1- Pyrgg engine
+        """
+    ),
 }
 
 MENU_ITEMS2 = {
@@ -62,6 +68,12 @@ SUFFIX_MENU = {
     15: ".gexf",
     16: ".gv"
 }
+
+ENGINE_MENU = {
+    1: "pyrgg",
+}
+
+ENGINE_MENU_INV = {v: k for k, v in ENGINE_MENU.items()}
 
 OUTPUT_FORMAT = {i: output_format[1:].upper()
                  for i, output_format in SUFFIX_MENU.items()}

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -3,7 +3,7 @@
 from textwrap import dedent, fill
 import os
 
-MENU_ITEMS1 = {
+MENU_ITEMS = {
     "file_name": "- File Name : ",
     "number_of_files": "- Number of Files : ",
     "output_format": dedent(
@@ -36,7 +36,7 @@ MENU_ITEMS1 = {
     ),
 }
 
-MENU_ITEMS2 = {
+PYRGG_ENGINE_PARAMS = {
     1: ["vertices", "- Vertices Number : "],
     2: ["min_edge", "- Min Edge Number (Connected to Each Vertex) : "],
     3: ["max_edge", "- Max Edge Number (Connected to Each Vertex) : "],

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -36,20 +36,6 @@ MENU_ITEMS = {
     ),
 }
 
-PYRGG_ENGINE_PARAMS = {
-    1: ["vertices", "- Vertices Number : "],
-    2: ["min_edge", "- Min Edge Number (Connected to Each Vertex) : "],
-    3: ["max_edge", "- Max Edge Number (Connected to Each Vertex) : "],
-    4: ["min_weight", "- Min Weight : "],
-    5: ["max_weight", "- Max Weight : "],
-    6: ["sign", "- Unsigned[0] or Signed[1]"],
-    7: ["direct", "- Undirected[0] or Directed[1]"],
-    8: ["self_loop", "- No Self Loop[0] or Self Loop[1]"],
-    9: ["multigraph", "- Simple[0] or Multigraph[1]"],
-    10: ["config", "- Save config[1] or not[0]"],
-}
-
-
 SUFFIX_MENU = {
     1: ".gr",
     2: ".json",
@@ -67,6 +53,19 @@ SUFFIX_MENU = {
     14: ".gml",
     15: ".gexf",
     16: ".gv"
+}
+
+PYRGG_ENGINE_PARAMS = {
+    1: ["vertices", "- Vertices Number : "],
+    2: ["min_edge", "- Min Edge Number (Connected to Each Vertex) : "],
+    3: ["max_edge", "- Max Edge Number (Connected to Each Vertex) : "],
+    4: ["min_weight", "- Min Weight : "],
+    5: ["max_weight", "- Max Weight : "],
+    6: ["sign", "- Unsigned[0] or Signed[1]"],
+    7: ["direct", "- Undirected[0] or Directed[1]"],
+    8: ["self_loop", "- No Self Loop[0] or Self Loop[1]"],
+    9: ["multigraph", "- Simple[0] or Multigraph[1]"],
+    10: ["config", "- Save config[1] or not[0]"],
 }
 
 ENGINE_MENU = {

--- a/pyrgg/test.py
+++ b/pyrgg/test.py
@@ -1140,7 +1140,22 @@ edge(28,21,28).
 edge(28,13,-13).
 <BLANKLINE>
 >>> input_dic=get_input(input_func=lambda x: str(len(x)))
-[Error] Invalid engine!
+>>> input_dic['sign']
+True
+>>> input_dic['vertices']
+20
+>>> input_dic['min_edge']
+47
+>>> input_dic['min_weight']
+15
+>>> input_dic['output_format']
+1
+>>> input_dic['max_weight']
+15
+>>> input_dic['file_name']
+'14'
+>>> input_dic['max_edge']
+47
 >>> random.seed(2)
 >>> tgf_maker('testfile', 0, 200, 10, 0, 2, True,True,True,False)
 7

--- a/pyrgg/test.py
+++ b/pyrgg/test.py
@@ -33,17 +33,17 @@ False
 True
 >>> is_float(None)
 False
->>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2})
->>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 5, 'max_edge': 5, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2}
+>>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2,"engine":1})
+>>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 5, 'max_edge': 5, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2,"engine":1}
 True
->>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":2})
->>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 4, 'max_edge': 4, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":2}
+>>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":2,"engine":-1})
+>>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 4, 'max_edge': 4, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":2,"engine":1}
 True
->>> result = input_filter({"file_name": "test","vertices": -5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":-1})
->>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 11, 'max_edge': 45, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":1}
+>>> result = input_filter({"file_name": "test","vertices": -5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":-1,"engine":1})
+>>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 11, 'max_edge': 45, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":1,"engine":1}
 True
->>> result = input_filter({"file_name": "test2","vertices": 23,"max_weight": 2,"min_weight": 80,"min_edge": 23,"max_edge": 1,"sign": True,"output_format": 1, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":100})
->>> result == {'min_weight': 2, 'vertices': 23, 'file_name': 'test2', 'max_edge': 23, 'min_edge': 1, 'max_weight': 80, 'output_format': 1, 'sign': True, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":100}
+>>> result = input_filter({"file_name": "test2","vertices": 23,"max_weight": 2,"min_weight": 80,"min_edge": 23,"max_edge": 1,"sign": True,"output_format": 1, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":100,"engine":1})
+>>> result == {'min_weight': 2, 'vertices': 23, 'file_name': 'test2', 'max_edge': 23, 'min_edge': 1, 'max_weight': 80, 'output_format': 1, 'sign': True, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":100,"engine":1}
 True
 >>> logger('test',100,50,1000,10,1,0,0,1,20,1,'2min')
 >>> file=open('logfile.log','r')

--- a/pyrgg/test.py
+++ b/pyrgg/test.py
@@ -1139,23 +1139,6 @@ edge(27,6,-50).
 edge(28,21,28).
 edge(28,13,-13).
 <BLANKLINE>
->>> input_dic=get_input(input_func=lambda x: str(len(x)))
->>> input_dic['sign']
-True
->>> input_dic['vertices']
-20
->>> input_dic['min_edge']
-47
->>> input_dic['min_weight']
-15
->>> input_dic['output_format']
-1
->>> input_dic['max_weight']
-15
->>> input_dic['file_name']
-'14'
->>> input_dic['max_edge']
-47
 >>> random.seed(2)
 >>> tgf_maker('testfile', 0, 200, 10, 0, 2, True,True,True,False)
 7

--- a/pyrgg/test.py
+++ b/pyrgg/test.py
@@ -1140,22 +1140,7 @@ edge(28,21,28).
 edge(28,13,-13).
 <BLANKLINE>
 >>> input_dic=get_input(input_func=lambda x: str(len(x)))
->>> input_dic['sign']
-True
->>> input_dic['vertices']
-20
->>> input_dic['min_edge']
-47
->>> input_dic['min_weight']
-15
->>> input_dic['output_format']
-1
->>> input_dic['max_weight']
-15
->>> input_dic['file_name']
-'14'
->>> input_dic['max_edge']
-47
+[Error] Invalid engine!
 >>> random.seed(2)
 >>> tgf_maker('testfile', 0, 200, 10, 0, 2, True,True,True,False)
 7

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -23,20 +23,20 @@ processing frameworks.
 <BLANKLINE>
 <BLANKLINE>
 ########################################
->>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2})
->>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 5, 'max_edge': 5, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2}
+>>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2,"engine":1})
+>>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 5, 'max_edge': 5, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2,"engine":1}
 True
->>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":10})
->>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 4, 'max_edge': 4, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":10}
+>>> result = input_filter({"file_name": "test","vertices": 5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":10,"engine":1})
+>>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 4, 'max_edge': 4, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":False,"number_of_files":10,"engine":1}
 True
->>> result = input_filter({"file_name": "test","vertices": -5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":-1})
->>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 11, 'max_edge': 45, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":1}
+>>> result = input_filter({"file_name": "test","vertices": -5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":-1,"engine":-1})
+>>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 11, 'max_edge': 45, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":1,"engine":1}
 True
->>> result = input_filter({"file_name": "test","vertices": -5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":-1})
->>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 11, 'max_edge': 45, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":1}
+>>> result = input_filter({"file_name": "test","vertices": -5,"max_weight": 1000,"min_weight":455,"min_edge": -45,"max_edge": -11,"sign": False,"output_format": 19, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":-1,"engine":1})
+>>> result == {'output_format': 1, 'min_weight': 455, 'min_edge': 11, 'max_edge': 45, 'file_name': 'test', 'vertices': 5, 'max_weight': 1000, 'sign': False, "direct": False,"self_loop": False,"multigraph":True,"number_of_files":1,"engine":1}
 True
->>> result = input_filter({"file_name": "test2","vertices": 23,"max_weight": 2,"min_weight": 80,"min_edge": 23,"max_edge": 1,"sign": True,"output_format": 1, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2})
->>> result == {'min_weight': 2, 'vertices': 23, 'file_name': 'test2', 'max_edge': 23, 'min_edge': 1, 'max_weight': 80, 'output_format': 1, 'sign': True, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2}
+>>> result = input_filter({"file_name": "test2","vertices": 23,"max_weight": 2,"min_weight": 80,"min_edge": 23,"max_edge": 1,"sign": True,"output_format": 1, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2,"engine":1})
+>>> result == {'min_weight': 2, 'vertices': 23, 'file_name': 'test2', 'max_edge': 23, 'min_edge': 1, 'max_weight': 80, 'output_format': 1, 'sign': True, "direct": False,"self_loop": True,"multigraph":False,"number_of_files":2,"engine":1}
 True
 >>> logger('test',100,50,1000,10,1,0,0,1,20,1,'2min')
 >>> file=open('logfile.log','r')
@@ -154,7 +154,7 @@ Traceback (most recent call last):
         ...
 TypeError: edge_gen() missing 1 required positional argument: 'sign'
 >>> prev_item = ""
->>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":3,"config":False}
+>>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":3,"config":False,"engine":1}
 >>> def input_func_test(input_data):
 ...    global prev_item
 ...    for item in pyrgg.params.MENU_ITEMS1:
@@ -194,8 +194,10 @@ TypeError: edge_gen() missing 1 required positional argument: 'sign'
 True
 >>> input_data["weight"]
 True
+>>> input_data["engine"]
+1
 >>> prev_item = ""
->>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"1.2","min_edge":"10000","max_edge":"2","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":-1,"config":True}
+>>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"1.2","min_edge":"10000","max_edge":"2","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":-1,"config":True,"engine":1}
 >>> input_data = get_input(input_func_test)
 >>> input_data["vertices"]
 120
@@ -213,6 +215,8 @@ True
 True
 >>> input_data["weight"]
 True
+>>> input_data["engine"]
+1
 >>> loaded_config = check_for_config(input_func_conf_test1)
 >>> input_data["config"]
 True
@@ -244,7 +248,7 @@ Config files detected in current directory are listed below:
 >>> loaded_config == None
 True
 >>> prev_item = ""
->>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"0","multigraph":"0","file_name":"File 2","output_format":"200","weight":"0","number_of_files":-1,"error":"120","config":False}
+>>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"0","multigraph":"0","file_name":"File 2","output_format":"200","weight":"0","number_of_files":-1,"error":"120","config":False,"engine":1}
 >>> input_data = get_input(input_func_test)
 >>> input_data["vertices"]
 120
@@ -262,14 +266,14 @@ True
 True
 >>> input_data["multigraph"]
 False
->>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"2","multigraph":"400","file_name":"File 2","output_format":"200","weight":"1","error":"120","number_of_files":2,"config":False}
+>>> input_func_dict = {"vertices":"120","max_weight":"110.45","min_weight":"test","min_edge":"10000","max_edge":"2","sign":"1","direct":"-2","self_loop":"2","multigraph":"400","file_name":"File 2","output_format":"200","weight":"1","error":"120","number_of_files":2,"config":False,"engine":1}
 >>> input_data = get_input(input_func_test)
 [Error] Bad input!
 >>> input_data["min_weight"]
 110.45
 >>> input_data["max_weight"]
 120
->>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"1","file_name":"File 1","output_format":"2","weight":"test","error":"2","number_of_files":2,"config":False}
+>>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"1","file_name":"File 1","output_format":"2","weight":"test","error":"2","number_of_files":2,"config":False,"engine":1}
 >>> input_data = get_input(input_func_test)
 [Error] Bad input!
 >>> input_data["weight"]

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -157,16 +157,16 @@ TypeError: edge_gen() missing 1 required positional argument: 'sign'
 >>> input_func_dict = {"vertices":"120","max_weight":"110","min_weight":"0","min_edge":"1","max_edge":"1000","sign":"1","direct":"1","self_loop":"1","multigraph":"0","file_name":"File 1","output_format":"2","weight":"1","error":"120","number_of_files":3,"config":False,"engine":1}
 >>> def input_func_test(input_data):
 ...    global prev_item
-...    for item in pyrgg.params.MENU_ITEMS1:
-...        if input_data == pyrgg.params.MENU_ITEMS1[item]:
+...    for item in pyrgg.params.MENU_ITEMS:
+...        if input_data == pyrgg.params.MENU_ITEMS[item]:
 ...            if item != prev_item :
 ...                prev_item = item
 ...                return input_func_dict[item]
 ...            else:
 ...                return input_func_dict["error"]
-...    for index in pyrgg.params.MENU_ITEMS2:
-...        item1 = pyrgg.params.MENU_ITEMS2[index][0]
-...        item2 = pyrgg.params.MENU_ITEMS2[index][1]
+...    for index in pyrgg.params.PYRGG_ENGINE_PARAMS:
+...        item1 = pyrgg.params.PYRGG_ENGINE_PARAMS[index][0]
+...        item2 = pyrgg.params.PYRGG_ENGINE_PARAMS[index][1]
 ...        if input_data == item2:
 ...            if item1 != prev_item :
 ...                prev_item = item1


### PR DESCRIPTION
#### Reference Issues/PRs
#145 
#### What does this implement/fix? Explain your changes.
This PR will add `engine` parameter to the PyRGG menu. Until now we only have one engine (Pyrgg engine) but new engines will be proposed using this architecture.

I tried to develop it as cohesive as I can. Using `engine` parameter from `result_dict` we can control parameters needed for each generation method.

