### PR TITLE
New Engine: Labeled Tree Generator (using Prüfer sequence)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,4 +86,4 @@ jobs:
           python -m cProfile -s cumtime otherfile/profiles/gg_profile.py
     - name: Random Tree Generator
       run: |
-          python -m cProfile -s cumtime otherfile/profiles/t_profile.py
+          python -m cProfile -s cumtime otherfile/profiles/lt_profile.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,3 +84,6 @@ jobs:
     - name: cProfile - Random Geometric Graph Engine
       run: |
           python -m cProfile -s cumtime otherfile/profiles/gg_profile.py
+    - name: Random Tree Generator
+      run: |
+          python -m cProfile -s cumtime otherfile/profiles/t_profile.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `pyrgg.engines.labeled_tree` module
 ## [2.0] - 2025-12-23
 ### Added
 - `pyrgg.engines.geometric_graph` module

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ PyRGG will likely run on a modern dual core PC. Typical configuration is:
 	</tr>
 </table>
 
-### Labeled Tree Generator (using Prüfer sequence)
+### Labeled Tree Generator
 
 <table>
 	<tr>

--- a/README.md
+++ b/README.md
@@ -284,6 +284,19 @@ PyRGG will likely run on a modern dual core PC. Typical configuration is:
 	</tr>
 </table>
 
+### Labeled Tree Generator (using Prüfer sequence)
+
+<table>
+	<tr>
+		<th>Parameter</th>
+		<th>Description</th>
+	</tr>
+	<tr>
+		<td align="center">Vertices Number (n)</td>
+		<td align="center">The total number of vertices in the graph</td>
+	</tr>
+</table>
+
 ## Supported Formats
 
 ### DIMACS
@@ -735,6 +748,10 @@ If you use PyRGG in your research, we would appreciate citations to the followin
 <blockquote>17- Watts, Duncan J., and Steven H. Strogatz. "Collective dynamics of ‘small-world’networks." nature 393.6684 (1998): 440-442.</blockquote>
 
 <blockquote>18- Gilbert, Edward N. "Random plane networks." Journal of the society for industrial and applied mathematics 9.4 (1961): 533-543.</blockquote>
+
+<blockquote>19- Prüfer, Heinz. "Neuer beweis eines satzes über permutationen." Arch. Math. Phys 27.1918 (1918): 742-744.</blockquote>
+
+<blockquote>20- Gottlieb, Jens, et al. "Prüfer numbers: A poor representation of spanning trees for evolutionary search." Proceedings of the genetic and evolutionary computation conference. Vol. 343. 2001.</blockquote>
 
 ## Show Your Support
 								

--- a/otherfile/profiles/lt_profile.py
+++ b/otherfile/profiles/lt_profile.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Labeled Tree Generator Engine Profile."""
+from pyrgg import *
+import pyrgg.engines.labeled_tree as lt_engine
+import random
+
+os.environ["PYRGG_TEST_MODE"] = "1"
+random.seed(400)
+
+lt_engine.generate_graph(
+    generate_dimacs_file,
+    'profile',
+    {
+        'vertices': 10000,
+    }
+)

--- a/pyrgg/__main__.py
+++ b/pyrgg/__main__.py
@@ -16,6 +16,7 @@ import pyrgg.engines.stochastic_block_model as sbm_engine
 import pyrgg.engines.barabasi_albert as ba_engine
 import pyrgg.engines.watts_strogatz as ws_engine
 import pyrgg.engines.geometric_graph as gg_engine
+import pyrgg.engines.labeled_tree as lt_engine
 
 GENERATOR_MENU = {
     1: generate_dimacs_file,
@@ -44,6 +45,7 @@ ENGINE_MAPPER = {
     5: ba_engine,
     6: ws_engine,
     7: gg_engine,
+    8: lt_engine,
 }
 
 

--- a/pyrgg/engines/labeled_tree.py
+++ b/pyrgg/engines/labeled_tree.py
@@ -41,7 +41,6 @@ def generate_edges(n: int) -> Tuple[Dict[int, List[int]], Dict[int, List[float]]
     _edge_dict[u].append(v)
     degree_dict[u] -= 1
     degree_dict[v] -= 1
-    assert edge_number == n - 1
     # refine the graph
     edge_dict = {x: [] for x in range(1, n + 1)}
     weight_dict = {x: [] for x in range(1, n + 1)}

--- a/pyrgg/engines/labeled_tree.py
+++ b/pyrgg/engines/labeled_tree.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Labeled Tree Generator Engine module."""
+from typing import List, Dict, Callable, Any, IO, Tuple
+from random import choice
+from pyrgg.params import ENGINE_MENU, PYRGG_LOGGER_ERROR_MESSAGE
+from pyrgg.functions import save_log
+
+
+def generate_edges(n: int) -> Tuple[Dict[int, List[int]], Dict[int, List[float]], int]:
+    """
+    Generate each vertex connection number.
+
+    :param n: number of vertices
+    """
+    prufer_seq = [choice(range(1, n + 1)) for _ in range(n - 2)]
+    edge_number = 0
+    _edge_dict = {x: [] for x in range(1, n + 1)}
+    # degree initialization:
+    degree_dict = {x: 1 for x in range(1, n + 1)}
+    for i in prufer_seq:
+        degree_dict[i] += 1
+    # tree construction:
+    for i in prufer_seq:
+        for j in range(1, n + 1):
+            if degree_dict[j] == 1:
+                edge_number += 1
+                _edge_dict[i].append(j)
+                degree_dict[i] -= 1
+                degree_dict[j] -= 1
+                break
+    # adding final edges:
+    u, v = None, None
+    for i in range(1, n + 1):
+        if degree_dict[i] == 1:
+            if u is None:
+                u = i
+            else:
+                v = i
+                break
+    edge_number += 1
+    _edge_dict[u].append(v)
+    degree_dict[u] -= 1
+    degree_dict[v] -= 1
+    assert edge_number == n - 1
+    # refine the graph
+    edge_dict = {x: [] for x in range(1, n + 1)}
+    weight_dict = {x: [] for x in range(1, n + 1)}
+    for i in range(1, n + 1):
+        for j in _edge_dict[i]:
+            if i < j:
+                edge_dict[i].append(j)
+                weight_dict[i].append(1)
+            else:
+                edge_dict[j].append(i)
+                weight_dict[j].append(1)
+    edge_dict = {x: sorted(y) for x, y in edge_dict.items()}
+    return [edge_dict, weight_dict, edge_number]
+
+
+def generate_graph(
+        gen_function: Callable,
+        file_name: str,
+        input_dict: Dict[str, Any]) -> int:
+    """
+    Generate a labeled tree using Prüfer sequence and return the number of edges.
+
+    Refer to (https://en.wikipedia.org/wiki/Pr%C3%BCfer_sequence).
+
+    :param gen_function: graph generator function
+    :param file_name: file name
+    :param input_dict: input data
+    """
+    edge_dict, weight_dict, edge_number = generate_edges(
+        input_dict['vertices'])
+    gen_function(
+        edge_dict,
+        weight_dict,
+        {
+            "file_name": file_name,
+            "vertices_number": input_dict['vertices'],
+            "edge_number": edge_number,
+            "weighted": False,
+            "max_weight": 1,
+            "min_weight": 1,
+            "direct": False,
+            "multigraph": False,
+        })
+    return edge_number
+
+
+def logger(file: IO, file_name: str, elapsed_time: str, input_dict: Dict[str, Any]) -> None:
+    """
+    Save generated tree logs.
+
+    :param file: file to write log into
+    :param file_name: file name
+    :param elapsed_time: elapsed time
+    :param input_dict: input data
+    """
+    try:
+        text = "Vertices : {vertices}\n".format(vertices=input_dict['vertices'])
+        text += "Total Edges : {edge_number}\n".format(edge_number=input_dict['edge_number'])
+        text += "Engine : {engine_index} ({engine_name})\n".format(
+            engine_index=input_dict['engine'], engine_name=ENGINE_MENU[input_dict['engine']])
+        save_log(file, file_name, elapsed_time, text)
+    except Exception:
+        print(PYRGG_LOGGER_ERROR_MESSAGE)

--- a/pyrgg/params.py
+++ b/pyrgg/params.py
@@ -18,6 +18,7 @@ MENU_ITEMS = {
         5- Barabasi-Albert - G(n, k)
         6- Watts-Strogatz - G(n, k, p)
         7- Random Geometric Graph - G(d, r)
+        8- Labeled Tree Generator - T(n)
         """
     )],
     2: ["file_name", "- File Name (Not Empty) : "],
@@ -73,6 +74,7 @@ ENGINE_MENU = {
     5: "ba",
     6: "ws",
     7: "gg",
+    8: "lt",
 }
 
 ENGINE_MENU_INV = {v: k for k, v in ENGINE_MENU.items()}
@@ -128,6 +130,10 @@ GG_ENGINE_PARAMS = {
     3: ["cutoff_threshold", "- Cutoff threshold distance (0 <= r <= 1) : "],
 }
 
+LT_ENGINE_PARAMS = {
+    1: ["vertices", "- Vertices Number (n > 2) : "],
+}
+
 ENGINE_PARAM_MAP = {
     1: PYRGG_ENGINE_PARAMS,
     2: ERG_ENGINE_PARAMS,
@@ -136,6 +142,7 @@ ENGINE_PARAM_MAP = {
     5: BA_ENGINE_PARAMS,
     6: WS_ENGINE_PARAMS,
     7: GG_ENGINE_PARAMS,
+    8: LT_ENGINE_PARAMS,
 }
 
 OUTPUT_FORMAT = {i: output_format[1:].upper()

--- a/test/engines/labeled_tree_test.py
+++ b/test/engines/labeled_tree_test.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+"""
+>>> from pyrgg.functions import *
+>>> from pyrgg.graph_gen import *
+>>> import pyrgg.params
+>>> import random
+>>> import os
+>>> import json
+>>> import pyrgg.engines.labeled_tree as engine
+>>> os.environ["PYRGG_TEST_MODE"] = "1"
+>>> ######################################
+>>> ## ========= logger function =========
+>>> ######################################
+>>> with open('logfile.log','a') as file:
+...     engine.logger(file,'test','2min',{'vertices':100,'edge_number':99,'engine':8,'output_format':1})
+>>> file = open('logfile.log','r')
+>>> print("\\n".join(file.read().splitlines()[1:-1]))
+Filename : test
+Vertices : 100
+Total Edges : 99
+Engine : 8 (lt)
+Elapsed Time : 2min
+>>> class StrError:
+...     def __init__(self):
+...         pass
+...     def __str__(self):
+...         raise ValueError
+>>> str_error_object = StrError()
+>>> with open('logfile.log','a') as file:
+...     engine.logger(file,'test','2min',{'vertices':str_error_object,'edge_number':99,'engine':8,'output_format':1})
+[Error] Logger failed!
+>>> ##########################################
+>>> ## ========= generate_edges function =========
+>>> ##########################################
+>>> random.seed(2)
+>>> edge_dict, weight_dict, edge_number = engine.generate_edges(20)
+>>> edge_dict == {1: [2], 2: [16, 19], 3: [4, 5, 12], 4: [], 5: [], 6: [8, 14, 19], 7: [15, 20], 8: [], 9: [10, 20], 10: [11], 11: [], 12: [17, 18], 13: [14, 17], 14: [], 15: [], 16: [], 17: [], 18: [20], 19: [], 20: []}
+True
+>>> edge_number == 19
+True
+>>> random.seed(6)
+>>> edge_dict, weight_dict, edge_number = engine.generate_edges(2)
+>>> edge_dict == {1: [2], 2: []}
+True
+>>> edge_number == 1
+True
+>>> engine.generate_edges()
+Traceback (most recent call last):
+        ...
+TypeError: generate_edges() missing 1 required positional argument: 'n'
+>>> #########################################
+>>> ## ========= generate_graph function =========
+>>> #########################################
+>>> #################### generate_dimacs_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_dimacs_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.gr','r')
+>>> print(file.read())
+c FILE                  :testfile.gr
+c No. of vertices       :10
+c No. of edges          :9
+c Max. weight           :1
+c Min. weight           :1
+p sp 10 9
+a 1 2 1
+a 1 4 1
+a 2 6 1
+a 2 7 1
+a 3 5 1
+a 3 6 1
+a 5 8 1
+a 5 10 1
+a 9 10 1
+<BLANKLINE>
+>>> #################### generate_json_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_json_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.json','r')
+>>> testfile_1=json.load(file)
+>>> testfile_1['graph']['nodes'][1]
+{'id': 2}
+>>> testfile_1['graph']['edges'][1]['source']
+1
+>>> testfile_1['graph']['edges'][1]['target']
+4
+>>> #################### generate_csv_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_csv_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.csv','r')
+>>> print(file.read())
+1,2,1
+1,4,1
+2,6,1
+2,7,1
+3,5,1
+3,6,1
+5,8,1
+5,10,1
+9,10,1
+<BLANKLINE>
+>>> #################### generate_gdf_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_gdf_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.gdf','r')
+>>> print(file.read())
+nodedef>name VARCHAR,label VARCHAR
+1,Node1
+2,Node2
+3,Node3
+4,Node4
+5,Node5
+6,Node6
+7,Node7
+8,Node8
+9,Node9
+10,Node10
+edgedef>node1 VARCHAR,node2 VARCHAR,weight DOUBLE
+1,2,1
+1,4,1
+2,6,1
+2,7,1
+3,5,1
+3,6,1
+5,8,1
+5,10,1
+9,10,1
+<BLANKLINE>
+>>> #################### generate_gl_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_gl_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.gl','r')
+>>> print(file.read())
+1 2:1 4:1
+2 6:1 7:1
+3 5:1 6:1
+5 8:1 10:1
+9 10:1
+<BLANKLINE>
+>>> #################### generate_mtx_file ####################
+>>> from scipy.io import mmread
+>>> random.seed(2)
+>>> engine.generate_graph(generate_mtx_file, 'testfile', {'vertices':10})
+9
+>>> g = mmread("testfile.mtx")
+>>> print(g.data.tolist())
+[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+>>> #################### generate_tsv_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_tsv_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.tsv','r')
+>>> print(file.read())
+1	2	1
+1	4	1
+2	6	1
+2	7	1
+3	5	1
+3	6	1
+5	8	1
+5	10	1
+9	10	1
+<BLANKLINE>
+>>> #################### generate_wel_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_wel_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.wel','r')
+>>> print(file.read())
+1 2 1
+1 4 1
+2 6 1
+2 7 1
+3 5 1
+3 6 1
+5 8 1
+5 10 1
+9 10 1
+<BLANKLINE>
+>>> #################### generate_lp_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_lp_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.lp','r')
+>>> print(file.read())
+node(1).
+node(2).
+node(3).
+node(4).
+node(5).
+node(6).
+node(7).
+node(8).
+node(9).
+node(10).
+edge(1,2,1).
+edge(1,4,1).
+edge(2,6,1).
+edge(2,7,1).
+edge(3,5,1).
+edge(3,6,1).
+edge(5,8,1).
+edge(5,10,1).
+edge(9,10,1).
+<BLANKLINE>
+>>> #################### generate_tgf_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_tgf_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.tgf','r')
+>>> print(file.read())
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+#
+1 2 1
+1 4 1
+2 6 1
+2 7 1
+3 5 1
+3 6 1
+5 8 1
+5 10 1
+9 10 1
+<BLANKLINE>
+>>> #################### generate_dl_file ####################
+>>> random.seed(2)
+>>> engine.generate_graph(generate_dl_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.dl','r')
+>>> print(file.read())
+dl
+format=edgelist1
+n=10
+data:
+1 2 1
+1 4 1
+2 6 1
+2 7 1
+3 5 1
+3 6 1
+5 8 1
+5 10 1
+9 10 1
+<BLANKLINE>
+>>> #################### generate_gml_file ####################
+>>> from networkx.readwrite.gml import read_gml
+>>> random.seed(2)
+>>> engine.generate_graph(generate_gml_file, 'testfile', {'vertices':10})
+9
+>>> gml1 = read_gml("testfile.gml")
+>>> type(gml1)
+<class 'networkx.classes.graph.Graph'>
+>>> #################### generate_gexf_file ####################
+>>> from networkx.readwrite.gexf import read_gexf
+>>> random.seed(2)
+>>> engine.generate_graph(generate_gexf_file, 'testfile', {'vertices':10})
+9
+>>> gexf1 = read_gexf("testfile.gexf")
+>>> type(gexf1)
+<class 'networkx.classes.graph.Graph'>
+>>> #################### generate_dot_file ####################
+>>> import pydot
+>>> random.seed(2)
+>>> engine.generate_graph(generate_dot_file, 'testfile', {'vertices':10})
+9
+>>> file=open('testfile.gv','r')
+>>> g1 = pydot.graph_from_dot_data(file.read())
+>>> g1[0].get_type()
+'graph'
+>>> len(g1[0].get_edge_list())
+9
+>>> file.close()
+>>> os.remove('testfile.gr')
+>>> os.remove('testfile.json')
+>>> os.remove('testfile.csv')
+>>> os.remove('testfile.gdf')
+>>> os.remove('testfile.gl')
+>>> os.remove('testfile.mtx')
+>>> os.remove('testfile.tsv')
+>>> os.remove('testfile.wel')
+>>> os.remove('testfile.lp')
+>>> os.remove('testfile.tgf')
+>>> os.remove('testfile.dl')
+>>> os.remove('testfile.gml')
+>>> os.remove('testfile.gexf')
+>>> os.remove('testfile.gv')
+>>> os.remove('logfile.log')
+"""

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -180,6 +180,14 @@ False
 ...                return input_func_dict[item1]
 ...            else:
 ...                return input_func_dict["error"]
+...    for index in pyrgg.params.LT_ENGINE_PARAMS:
+...        item1, item2 = pyrgg.params.LT_ENGINE_PARAMS[index]
+...        if input_data == item2:
+...            if item1 != prev_item :
+...                prev_item = item1
+...                return input_func_dict[item1]
+...            else:
+...                return input_func_dict["error"]
 >>> def input_func_conf_test1(input_data):
 ...     return "1"
 >>> def input_func_conf_test2(input_data):


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
This PR adds new engine which generates random labeled tree using Prufer sequence method.
 
#### Any other comments?
I double-checked the generated examples from examples from [here](https://mathworld.wolfram.com/PrueferCode.html) to make sure the correct implementation. I added a refinement at the end of the generation algorithm to make the edge_dict sorted and incremental, when i is connected to j `edge_dict[i]` has `j` if i < j.